### PR TITLE
Bump new version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 FROM golang:1.10.3-alpine3.7
 
-# Install dependencies
-RUN apk add --no-cache git make ca-certificates curl gcc musl-dev
-
-# Install dep
-RUN curl -sfL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
-# Install golangci-lint
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
-
-# Install gometalinter
-RUN go get -u gopkg.in/alecthomas/gometalinter.v2      \
-    && cp /go/bin/gometalinter.v2 /go/bin/gometalinter \
+RUN apk add --no-cache git make ca-certificates curl gcc musl-dev                    \
+    && curl -sfL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
+    && go get -u github.com/golangci/golangci-lint/cmd/golangci-lint                 \
+    && go get -u gopkg.in/alecthomas/gometalinter.v2                                 \
+    && cp /go/bin/gometalinter.v2 /go/bin/gometalinter                               \
     && gometalinter --install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,4 @@ FROM golang:1.10.3-alpine3.7
 
 RUN apk add --no-cache git make ca-certificates curl gcc musl-dev                    \
     && curl -sfL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
-    && go get -u github.com/golangci/golangci-lint/cmd/golangci-lint                 \
-    && go get -u gopkg.in/alecthomas/gometalinter.v2                                 \
-    && cp /go/bin/gometalinter.v2 /go/bin/gometalinter                               \
-    && gometalinter --install
+    && go get -u github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM golang:1.10.2-alpine3.7
+FROM golang:1.10.3-alpine3.7
 
-RUN apk add --no-cache git make ca-certificates curl gcc musl-dev       \
-    && go get -u github.com/golang/dep/cmd/dep                          \
-    && go get -u github.com/golangci/golangci-lint/cmd/golangci-lint    \
-    && go get -u gopkg.in/alecthomas/gometalinter.v2                    \
-    && cp /go/bin/gometalinter.v2 /go/bin/gometalinter                  \
+# Install dependencies
+RUN apk add --no-cache git make ca-certificates curl gcc musl-dev
+
+# Install dep
+RUN curl -sfL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+# Install golangci-lint
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+
+# Install gometalinter
+RUN go get -u gopkg.in/alecthomas/gometalinter.v2      \
+    && cp /go/bin/gometalinter.v2 /go/bin/gometalinter \
     && gometalinter --install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM golang:1.10.3-alpine3.7
 
 RUN apk add --no-cache git make ca-certificates curl gcc musl-dev                    \
     && curl -sfL https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
-    && go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+    && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = chapsuk/golang-baseimage
-VERSION = 1.10.2.2
+VERSION = 1.10.3
 
 .PHONY: release
 release: build tag push

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Golang build image with tools for build and check go programs.
 * dep
 * gcc
 * musl-dev
-* gometalinter with linters (`gometalinter --install`)
 * golangci-lint
 
 ## Versions
 
+* `1.10.3` - based on `golang:1.10.3-alpine3.7` removed `gometalinter`
 * `1.10.2.2` - added `golangci-lint`
 * `1.10.2.1` - added `gcc` and `musl-dev`
 * `1.10.2` - based on `golang:1.10.2-alpine3.7`


### PR DESCRIPTION
- update golang image to 1.10.3
- removed gometalinter
- install prebuild versions of dep / golangci